### PR TITLE
Changing paths for domains required for OIDC

### DIFF
--- a/charts/mealie/templates/configmap.yaml
+++ b/charts/mealie/templates/configmap.yaml
@@ -75,13 +75,13 @@ data:
   {{- end }}
 
   {{- if .Values.oidc.enabled }}
-  OIDC_AUTH_ENABLED: {{ .Values.oidc.enabled | quote }}
-  OIDC_SIGNUP_ENABLED: {{ .Values.oidc.signupEnabled | quote }}
+  OIDC_AUTH_ENABLED: {{ .Values.oidc.enabled }}
+  OIDC_SIGNUP_ENABLED: {{ .Values.oidc.signupEnabled }}
   OIDC_PROVIDER_NAME: {{ .Values.oidc.providerName | quote }}
   OIDC_CONFIGURATION_URL: {{ .Values.oidc.configurationUrl | quote }}
   OIDC_CLIENT_ID: {{ .Values.oidc.clientId | quote }}
   OIDC_CLIENT_SECRET: {{ .Values.oidc.clientSecret | quote }}
-  OIDC_AUTO_REDIRECT: {{ .Values.oidc.autoRedirect | quote }}
+  OIDC_AUTO_REDIRECT: {{ .Values.oidc.autoRedirect }}
   OIDC_USER_GROUP: {{ .Values.oidc.userGroup | quote }}
   OIDC_ADMIN_GROUP: {{ .Values.oidc.adminGroup | quote }}
   {{- end }}

--- a/charts/mealie/templates/ingressroute.yaml
+++ b/charts/mealie/templates/ingressroute.yaml
@@ -10,7 +10,7 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`{{ .Values.config.base_url }}`)
+    - match: Host(`{{ .Values.ingress.traefik.host }}`)
       kind: Rule
       services:
         - name: {{ .Values.service.name | quote }}
@@ -19,7 +19,7 @@ spec:
         - name: default-headers
           namespace: {{ .Release.namespace }}
 
-    - match: "Host(`{{ .Values.config.base_url }}`) && PathPrefix(`/admin`)"
+    - match: "Host(`{{ .Values.ingress.traefik.host }}`) && PathPrefix(`/admin`)"
       kind: Rule
       services:
         - name: {{ .Values.service.name | quote }}
@@ -30,7 +30,7 @@ spec:
         - name: default-headers
           namespace: {{ .Release.namespace }}
 
-    - match:  "Host(`{{ .Values.config.base_url }}`) && PathPrefix(`/docs`)"
+    - match:  "Host(`{{ .Values.ingress.traefik.host }}`) && PathPrefix(`/docs`)"
       kind: Rule
       services:
         - name: {{ .Values.service.name | quote }}
@@ -42,7 +42,7 @@ spec:
           namespace: {{ .Release.namespace }}        
 
 #For security reasons
-    - match: "Host(`{{ .Values.config.base_url }}`) && PathPrefix(`/api/recipes/create/url`)"
+    - match: "Host(`{{ .Values.ingress.traefik.host }}`) && PathPrefix(`/api/recipes/create/url`)"
       kind: Rule
       services:
         - name: {{ .Values.service.name | quote }}
@@ -54,7 +54,7 @@ spec:
           namespace: {{ .Release.namespace }}        
 
 #For security reasons
-    - match: "Host(`{{ .Values.config.base_url }}`) && PathPrefix(`/api/recipes/{id}/image`)"
+    - match: "Host(`{{ .Values.ingress.traefik.host }}`) && PathPrefix(`/api/recipes/{id}/image`)"
       kind: Rule
       services:
         - name: {{ .Values.service.name | quote }}

--- a/charts/mealie/values.yaml
+++ b/charts/mealie/values.yaml
@@ -2,6 +2,7 @@ appName: mealie-webservice
 ingress:
   traefik:
     enabled: true
+    host: YOUR-FQDN #This should be your FQDN
     ingressClass: traefik #Change this to match your IngressClass
     middleware:
       auth:
@@ -66,7 +67,7 @@ config:  # Backend configuration
   pgid: ""              #Default is 911
   default_group: "Cook-a-Meulenbroek" #Default is Home
   default_household: "Cook-a-Meulenbroek" #Default is Family
-  base_url: YOUR-AWESOME-DOMAIN-HERE # Do not include http or https.
+  base_url: https:/YOUR-AWESOME-DOMAIN-HERE # Do include http or https.
   token_time: ""        #Default is 48
   TZ: ""                #Default is "Europe/Amsterdam" 
   allow_signups: ""     #Default is false 
@@ -151,12 +152,12 @@ oidc:
   enabled: false
   signupEnabled: true  
   providerName: your-provider-here
-  configurationUrl: "https://authentik.example.com/application/o/mealie/.well-known/openid-configuration"
-  clientId: "mealie"
-  clientSecret: "SUPER_SECRET"
+  configurationUrl: https://authentik.example.com/application/o/mealie/.well-known/openid-configuration
+  clientId: mealie
+  clientSecret: SUPER_SECRET
   autoRedirect: true
-  userGroup: "mealie-production-users"
-  adminGroup: "mealie-production-admins"
+  userGroup: mealie-production-users
+  adminGroup: mealie-production-admins
 
 
 


### PR DESCRIPTION
Breaking change:
- Seperating traefik configuration and base URL in favor of OIDC configuration.
See the new values.yaml for the new layout (traefik and config subpaths)